### PR TITLE
Fix code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/backend/app/utils/file_operations.py
+++ b/backend/app/utils/file_operations.py
@@ -34,17 +34,23 @@ async def download_file(
         return False
 
 def write_json(filename: str, data: Any) -> None:
-    file_path: str = os.path.join(settings.XMLTV_DATA_DIR, filename)
+    file_path: str = os.path.normpath(os.path.join(settings.XMLTV_DATA_DIR, filename))
+    if not file_path.startswith(settings.XMLTV_DATA_DIR):
+        raise Exception("Access to the specified file is not allowed.")
     with open(file_path, 'w', encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=4)
     logger.info(f"Data saved to {filename}")
 
 def load_json(filename: str) -> Any:
-    file_path: str = os.path.join(settings.XMLTV_DATA_DIR, filename)
+    file_path: str = os.path.normpath(os.path.join(settings.XMLTV_DATA_DIR, filename))
+    if not file_path.startswith(settings.XMLTV_DATA_DIR):
+        raise Exception("Access to the specified file is not allowed.")
     with open(file_path, 'r', encoding="utf-8") as f:
         return json.load(f)
 
 def load_sources(filename: str) -> Dict[str, Any]:
-    file_path: str = os.path.join(filename)
+    file_path: str = os.path.normpath(os.path.join(settings.XMLTV_DATA_DIR, filename))
+    if not file_path.startswith(settings.XMLTV_DATA_DIR):
+        raise Exception("Access to the specified file is not allowed.")
     with open(file_path, 'r', encoding="utf-8") as f:
         return json.load(f)


### PR DESCRIPTION
Fixes [https://github.com/bacco007/webepg/security/code-scanning/4](https://github.com/bacco007/webepg/security/code-scanning/4)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root directory. This can be achieved by normalizing the path and verifying that it starts with the intended base directory. We will use `os.path.normpath` to normalize the path and then check if it starts with the base directory.

1. Normalize the constructed file path using `os.path.normpath`.
2. Verify that the normalized path starts with the base directory (`settings.XMLTV_DATA_DIR`).
3. Raise an exception if the path is not within the base directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
